### PR TITLE
Adds draw method for bitmaps with defined width

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Nokia 5110 LCD library
-version=2.5.0
+version=2.6.0
 author=Dimitris Platis
 maintainer=Dimitris Platis <dimitris@plat.is>
 sentence=Arduino library for driving the Nokia 5110 LCD

--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -227,7 +227,7 @@ bool Nokia_LCD::draw(const unsigned char bitmap[],
                      const unsigned int bitmap_size,
                      const bool read_from_progmem) {
     
-    return Nokia_LCD::draw(bitmap, bitmap_size, kTotal_columns, read_from_progmem);
+    return Nokia_LCD::draw(bitmap, bitmap_size, read_from_progmem);
 }
 
 bool Nokia_LCD::draw(const unsigned char bitmap[],

--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -235,7 +235,7 @@ bool Nokia_LCD::draw(const unsigned char bitmap[],
                      const unsigned int bitmap_width,
                      const bool read_from_progmem) {
     bool out_of_bounds = false;
-    const unsigned int x_start_position = mX_cursor;
+    const unsigned int initialX = mX_cursor;
     for (unsigned int i = 0; i < bitmap_size; i++) {
         unsigned char pixel =
             read_from_progmem ? pgm_read_byte_near(bitmap + i) : bitmap[i];
@@ -243,7 +243,7 @@ bool Nokia_LCD::draw(const unsigned char bitmap[],
             pixel = ~pixel;
         }
         sendData(pixel, false);
-        out_of_bounds = updateCursorPosition(x_start_position, bitmap_width) || out_of_bounds; 
+        out_of_bounds = updateCursorPosition(initialX, bitmap_width) || out_of_bounds; 
     }
 
     return out_of_bounds;

--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -245,7 +245,7 @@ bool Nokia_LCD::draw(const unsigned char bitmap[],
         if (mInverted) {
             pixel = ~pixel;
         }
-        send(pixel, true, false);
+        sendData(pixel, false);
         out_of_bounds = updateCursorPosition(currentX, bitmap_width) || out_of_bounds; 
     }
 
@@ -256,13 +256,15 @@ void Nokia_LCD::sendCommand(const unsigned char command) {
     send(command, false);
 }
 
-bool Nokia_LCD::sendData(const unsigned char data) { return send(data, true); }
+bool Nokia_LCD::sendData(const unsigned char data, const bool update_cursor) { return send(data, true, update_cursor); }
 
 
 bool Nokia_LCD::updateCursorPosition(const unsigned int x_start_position, const unsigned int x_end_position) {
     bool out_of_bounds = false;
 
-    mX_cursor = (mX_cursor + 1) % (x_end_position + x_start_position);  // Column
+    mX_cursor = (mX_cursor + 1) % (x_start_position + x_end_position);  // Used to determine if X reached the right margin. 
+                                                                        // E.g. starts drawing on column 10, an image of 25px width, 
+                                                                        // X will reach the right margin at 35px, so we have to break line
     // Calculate the cursor position after the byte being sent
     if (mX_cursor == 0) {
         mX_cursor = x_start_position;      // return X to the initial position 
@@ -274,7 +276,7 @@ bool Nokia_LCD::updateCursorPosition(const unsigned int x_start_position, const 
         }
     }
 
-    setCursor(mX_cursor, mY_cursor);     // update the cursor position   
+    setCursor(mX_cursor, mY_cursor);     // updates the cursor position   
     return out_of_bounds;
 }
 

--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -224,16 +224,9 @@ bool Nokia_LCD::printCharacter(char character) {
 }
 
 bool Nokia_LCD::draw(const unsigned char bitmap[],
-                     const unsigned int bitmap_size,
-                     const bool read_from_progmem) {
-
-    return Nokia_LCD::draw(bitmap, bitmap_size, nokia_lcd::kDisplay_max_width, read_from_progmem);
-}
-
-bool Nokia_LCD::draw(const unsigned char bitmap[],
-                     const unsigned int bitmap_size,
-                     const unsigned int bitmap_width,
-                     const bool read_from_progmem) {
+                     const unsigned int bitmap_size,                     
+                     const bool read_from_progmem,
+                     const unsigned int bitmap_width) {
     bool out_of_bounds = false;
     const unsigned int initialX = mX_cursor;
     for (unsigned int i = 0; i < bitmap_size; i++) {

--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -20,9 +20,9 @@ const LcdFont nokiaFont{
 
 // Each row is made of 8-bit columns
 const unsigned int kTotal_rows =
-    kDisplay_max_height / Nokia_LCD_Fonts::kRows_per_character;
-const unsigned int kTotal_columns = kDisplay_max_width;
-const unsigned int kTotal_bits = kDisplay_max_width * kTotal_rows;
+    nokia_lcd::kDisplay_max_height / Nokia_LCD_Fonts::kRows_per_character;
+const unsigned int kTotal_columns = nokia_lcd::kDisplay_max_width;
+const unsigned int kTotal_bits = nokia_lcd::kDisplay_max_width * kTotal_rows;
 const char kNull_char = '\0';
 const uint8_t kMax_number_length = 11;  // Size of unsigned long (10) + null
 }  // namespace
@@ -133,7 +133,7 @@ void Nokia_LCD::setBacklight(bool enabled) {
 }
 
 bool Nokia_LCD::setCursor(uint8_t x, uint8_t y) {
-    if (x >= kDisplay_max_width || y >= kTotal_rows) {
+    if (x >= nokia_lcd::kDisplay_max_width || y >= kTotal_rows) {
         return false;
     }
 
@@ -226,8 +226,8 @@ bool Nokia_LCD::printCharacter(char character) {
 bool Nokia_LCD::draw(const unsigned char bitmap[],
                      const unsigned int bitmap_size,
                      const bool read_from_progmem) {
-    
-    return Nokia_LCD::draw(bitmap, bitmap_size, read_from_progmem);
+
+    return Nokia_LCD::draw(bitmap, bitmap_size, nokia_lcd::kDisplay_max_width, read_from_progmem);
 }
 
 bool Nokia_LCD::draw(const unsigned char bitmap[],

--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -13,9 +13,6 @@
 #include "Nokia_LCD_Fonts.h"
 
 namespace {
-const uint8_t kDisplay_max_width = 84;
-const uint8_t kDisplay_max_height = 48;
-
 // Instantiate the default font
 const LcdFont nokiaFont{
     [](char c) { return Nokia_LCD_Fonts::kDefault_font[c - 0x20]; },
@@ -238,7 +235,7 @@ bool Nokia_LCD::draw(const unsigned char bitmap[],
                      const unsigned int bitmap_width,
                      const bool read_from_progmem) {
     bool out_of_bounds = false;
-    const unsigned int currentX = mX_cursor;
+    const unsigned int x_start_position = mX_cursor;
     for (unsigned int i = 0; i < bitmap_size; i++) {
         unsigned char pixel =
             read_from_progmem ? pgm_read_byte_near(bitmap + i) : bitmap[i];
@@ -246,7 +243,7 @@ bool Nokia_LCD::draw(const unsigned char bitmap[],
             pixel = ~pixel;
         }
         sendData(pixel, false);
-        out_of_bounds = updateCursorPosition(currentX, bitmap_width) || out_of_bounds; 
+        out_of_bounds = updateCursorPosition(x_start_position, bitmap_width) || out_of_bounds; 
     }
 
     return out_of_bounds;
@@ -256,8 +253,9 @@ void Nokia_LCD::sendCommand(const unsigned char command) {
     send(command, false);
 }
 
-bool Nokia_LCD::sendData(const unsigned char data, const bool update_cursor) { return send(data, true, update_cursor); }
+bool Nokia_LCD::sendData(const unsigned char data) { return sendData(data, true); }
 
+bool Nokia_LCD::sendData(const unsigned char data, const bool update_cursor) { return send(data, true, update_cursor); }
 
 bool Nokia_LCD::updateCursorPosition(const unsigned int x_start_position, const unsigned int x_end_position) {
     bool out_of_bounds = false;
@@ -305,7 +303,7 @@ bool Nokia_LCD::send(const unsigned char lcd_byte, const bool is_data, const boo
         return false;
     }
 
-    return updateCursorPosition(0, kTotal_columns);
+    return updateCursorPosition();
 }
 
 bool Nokia_LCD::print(int number) {
@@ -333,7 +331,6 @@ bool Nokia_LCD::print(long number) {
 }
 
 bool Nokia_LCD::print(unsigned long number) {
-    const uint8_t base = 10;  // We shall treat all numbers as decimals
     // The log base 10 of the number increased by 1 indicates how many digits
     // there are in a number.
     const uint8_t length_as_string =

--- a/src/Nokia_LCD.h
+++ b/src/Nokia_LCD.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include "LCD_Fonts.h"
 
-namespace {
+namespace nokia_lcd {
     // Display constants
     const uint8_t kDisplay_max_width = 84;
     const uint8_t kDisplay_max_height = 48;
@@ -197,16 +197,16 @@ public:
      * @param  bitmap            The bitmap to be displayed
      * @param  bitmap_size       The size of the bitmap to be displayed up to
      *                           504 bits
-     * @param  bitmap_width      The bitmap width. By default uses the screen width.
-     * @param read_from_progmem  Whether the bitmap is stored in flash memory
+     * @param  bitmap_width      The bitmap width.
+     * @param  read_from_progmem Whether the bitmap is stored in flash memory
      *                           instead of SRAM. Default read from flash.
      * @return                   True if out of bounds error | False otherwise
      */
-    bool draw(const unsigned char bitmap[],
+    bool draw(const unsigned char bitmap[], 
               const unsigned int bitmap_size,
-              const unsigned int bitmap_width = kDisplay_max_width,
+              const unsigned int bitmap_width,
               const bool read_from_progmem = true);
-
+    
     /**
      * Sends the specified byte as a command to the display.
      * @param command The byte to be sent as a command.
@@ -275,7 +275,7 @@ private:
      *                              breaking. When drawing a bitmap, it is the image width.
 *                                   Defaults to screen width.
      */
-    bool updateCursorPosition(const unsigned int x_start_position = 0, const unsigned int x_end_position = kDisplay_max_width);
+    bool updateCursorPosition(const unsigned int x_start_position = 0, const unsigned int x_end_position = nokia_lcd::kDisplay_max_width);
 
     /**
      * Prints the specified character

--- a/src/Nokia_LCD.h
+++ b/src/Nokia_LCD.h
@@ -184,28 +184,14 @@ public:
      *                           504 bits
      * @param read_from_progmem  Whether the bitmap is stored in flash memory
      *                           instead of SRAM. Default read from flash.
-     * @return                   True if out of bounds error | False otherwise
-     */
-    bool draw(const unsigned char bitmap[], const unsigned int bitmap_size,
-              const bool read_from_progmem = true);
-    /**
-     * Draws the supplied bitmap on the screen starting at the current cursor
-     * location. The bitmap can contain up to 504 bits which is the amount of
-     * pixels in the display. When bitmap is smaller than screen width, is 
-     * necessary to inform the width.
-     *  
-     * @param  bitmap            The bitmap to be displayed
-     * @param  bitmap_size       The size of the bitmap to be displayed up to
-     *                           504 bits
      * @param  bitmap_width      The bitmap width.
-     * @param  read_from_progmem Whether the bitmap is stored in flash memory
-     *                           instead of SRAM. Default read from flash.
      * @return                   True if out of bounds error | False otherwise
+     * 
      */
     bool draw(const unsigned char bitmap[], 
               const unsigned int bitmap_size,
-              const unsigned int bitmap_width,
-              const bool read_from_progmem = true);
+              const bool read_from_progmem = true,
+              const unsigned int bitmap_width = nokia_lcd::kDisplay_max_width);
     
     /**
      * Sends the specified byte as a command to the display.

--- a/src/Nokia_LCD.h
+++ b/src/Nokia_LCD.h
@@ -203,18 +203,6 @@ public:
               const bool read_from_progmem = true);
 
     /**
-     * Updates mX_cursor and mY_cursor position. By default it uses the whole 
-     * screen width in order to calculate row changing and out of bounds.
-     * 
-     * @param x_start_position      Left alignment position. Used for drawing 
-     *                              bitmaps smaller than screen width. Defaults to zero.
-     * @param x_end_position        Position where the cursor will consider a line 
-     *                              breaking. When drawing a bitmap, it is the image width.
-*                                   Defaults to screen width.
-     */
-    bool updateCursorPosition(const unsigned int x_start_position, const unsigned int x_end_position);
-
-    /**
      * Sends the specified byte as a command to the display.
      * @param command The byte to be sent as a command.
      */
@@ -222,10 +210,11 @@ public:
 
     /**
      * Sends the specified byte as (presentable) data to the display.
-     * @param data  The byte to be sent as presentable data.
-     * @return      True if out of bounds error | False otherwise
+     * @param data           The byte to be sent as presentable data.
+     * @param update_cursor  If false, the cursor position will be updated by the caller 
+     * @return               True if out of bounds error | False otherwise
      */
-    bool sendData(const unsigned char data);
+    bool sendData(const unsigned char data, const bool update_cursor = true);
 
     /**
      * Sets the flag to invert colors
@@ -262,6 +251,18 @@ private:
      * @return                True if out of bounds error | False otherwise
      */
     bool send(const unsigned char lcd_byte, const bool is_data, const bool update_cursor = true);
+
+    /**
+     * Updates mX_cursor and mY_cursor position. By default it uses the whole 
+     * screen width in order to calculate row changing and out of bounds.
+     * 
+     * @param x_start_position      Left alignment position. Used for drawing 
+     *                              bitmaps smaller than screen width. Defaults to zero.
+     * @param x_end_position        Position where the cursor will consider a line 
+     *                              breaking. When drawing a bitmap, it is the image width.
+*                                   Defaults to screen width.
+     */
+    bool updateCursorPosition(const unsigned int x_start_position, const unsigned int x_end_position);
 
     /**
      * Prints the specified character

--- a/src/Nokia_LCD.h
+++ b/src/Nokia_LCD.h
@@ -197,15 +197,14 @@ public:
      * @param  bitmap            The bitmap to be displayed
      * @param  bitmap_size       The size of the bitmap to be displayed up to
      *                           504 bits
-     * @param  bitmap_width      The bitmap width. Used to draw on any position 
-     *                           of screen
+     * @param  bitmap_width      The bitmap width. By default uses the screen width.
      * @param read_from_progmem  Whether the bitmap is stored in flash memory
      *                           instead of SRAM. Default read from flash.
      * @return                   True if out of bounds error | False otherwise
      */
     bool draw(const unsigned char bitmap[],
               const unsigned int bitmap_size,
-              const unsigned int bitmap_width,
+              const unsigned int bitmap_width = kDisplay_max_width,
               const bool read_from_progmem = true);
 
     /**

--- a/src/Nokia_LCD.h
+++ b/src/Nokia_LCD.h
@@ -182,6 +182,37 @@ public:
      */
     bool draw(const unsigned char bitmap[], const unsigned int bitmap_size,
               const bool read_from_progmem = true);
+    /**
+     * Draws the supplied bitmap on the screen starting at the current cursor
+     * location. The bitmap can contain up to 504 bits which is the amount of
+     * pixels in the display. When bitmap is smaller than screen width, is 
+     * necessary to inform the width.
+     *  
+     * @param  bitmap            The bitmap to be displayed
+     * @param  bitmap_size       The size of the bitmap to be displayed up to
+     *                           504 bits
+     * @param  bitmap_width      The bitmap width. Used to draw on any position 
+     *                           of screen
+     * @param read_from_progmem  Whether the bitmap is stored in flash memory
+     *                           instead of SRAM. Default read from flash.
+     * @return                   True if out of bounds error | False otherwise
+     */
+    bool draw(const unsigned char bitmap[],
+              const unsigned int bitmap_size,
+              const unsigned int bitmap_width,
+              const bool read_from_progmem = true);
+
+    /**
+     * Updates mX_cursor and mY_cursor position. By default it uses the whole 
+     * screen width in order to calculate row changing and out of bounds.
+     * 
+     * @param x_start_position      Left alignment position. Used for drawing 
+     *                              bitmaps smaller than screen width. Defaults to zero.
+     * @param x_end_position        Position where the cursor will consider a line 
+     *                              breaking. When drawing a bitmap, it is the image width.
+*                                   Defaults to screen width.
+     */
+    bool updateCursorPosition(const unsigned int x_start_position, const unsigned int x_end_position);
 
     /**
      * Sends the specified byte as a command to the display.
@@ -225,11 +256,12 @@ private:
     /**
      * Sends the specified byte to the LCD via software SPI as data or a
      * command.
-     * @param lcd_byte The byte to be send to the LCD
-     * @param is_data  Whether the byte to be send is data (or a command)
-     * @return         True if out of bounds error | False otherwise
+     * @param lcd_byte        The byte to be send to the LCD
+     * @param is_data         Whether the byte to be send is data (or a command)
+     * @param update_cursor   If false, the cursor position will be updated by the caller 
+     * @return                True if out of bounds error | False otherwise
      */
-    bool send(const unsigned char lcd_byte, const bool is_data);
+    bool send(const unsigned char lcd_byte, const bool is_data, const bool update_cursor = true);
 
     /**
      * Prints the specified character

--- a/src/Nokia_LCD.h
+++ b/src/Nokia_LCD.h
@@ -14,6 +14,12 @@
 #include <stdint.h>
 #include "LCD_Fonts.h"
 
+namespace {
+    // Display constants
+    const uint8_t kDisplay_max_width = 84;
+    const uint8_t kDisplay_max_height = 48;
+}
+
 class Nokia_LCD {
 public:
     /**
@@ -211,10 +217,9 @@ public:
     /**
      * Sends the specified byte as (presentable) data to the display.
      * @param data           The byte to be sent as presentable data.
-     * @param update_cursor  If false, the cursor position will be updated by the caller 
      * @return               True if out of bounds error | False otherwise
      */
-    bool sendData(const unsigned char data, const bool update_cursor = true);
+    bool sendData(const unsigned char data);
 
     /**
      * Sets the flag to invert colors
@@ -253,16 +258,25 @@ private:
     bool send(const unsigned char lcd_byte, const bool is_data, const bool update_cursor = true);
 
     /**
+     * Sends the specified byte as (presentable) data to the display.
+     * @param data           The byte to be sent as presentable data.
+     * @param update_cursor  If false, the cursor position will be updated by the caller 
+     * @return               True if out of bounds error | False otherwise
+     */
+    bool sendData(const unsigned char data, const bool update_cursor);
+
+    /**
      * Updates mX_cursor and mY_cursor position. By default it uses the whole 
      * screen width in order to calculate row changing and out of bounds.
      * 
      * @param x_start_position      Left alignment position. Used for drawing 
      *                              bitmaps smaller than screen width. Defaults to zero.
+     *                              Defaults to zero.
      * @param x_end_position        Position where the cursor will consider a line 
      *                              breaking. When drawing a bitmap, it is the image width.
 *                                   Defaults to screen width.
      */
-    bool updateCursorPosition(const unsigned int x_start_position, const unsigned int x_end_position);
+    bool updateCursorPosition(const unsigned int x_start_position = 0, const unsigned int x_end_position = kDisplay_max_width);
 
     /**
      * Prints the specified character


### PR DESCRIPTION
Hello Dimitris, 
I'm creating a new draw() method where we pass the bitmap width. That way, I can draw a bitmap of any size at any position without affecting other pixels around.

Original image:
![space](https://user-images.githubusercontent.com/7151022/128585017-708c516c-a4b0-499b-b9d8-562fc0af9565.png)

setCursor(0,4);
![IMG_20210806_204715](https://user-images.githubusercontent.com/7151022/128585086-5d534a6e-4a54-4227-9d63-a139ca02214a.jpg)

setCursor(65,0);
![IMG_20210806_204614](https://user-images.githubusercontent.com/7151022/128585087-429e82f2-cec2-4f6a-9a26-aa133516a6cd.jpg)

setCursor(0,0);
![IMG_20210806_204420](https://user-images.githubusercontent.com/7151022/128585089-fc4e13a2-746c-42cd-aa28-99a25212ff73.jpg)


Let me know your thoughts. 