### PR TITLE
Enable compilation for RP2040

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Nokia 5110 LCD library
-version=2.6.1
+version=2.6.2
 author=Dimitris Platis
 maintainer=Dimitris Platis <dimitris@plat.is>
 sentence=Arduino library for driving the Nokia 5110 LCD


### PR DESCRIPTION
* Include `avr/pgmspace.h` if available
  Other platforms aside of AVR may have that header
* Improve usage of SPI and stop using deprecated functions

Fixes #21